### PR TITLE
SCRUM-28: Create backend functionality for the history of mood and journal entries

### DIFF
--- a/server/controller/userController.js
+++ b/server/controller/userController.js
@@ -156,7 +156,7 @@ router.get("/:firebaseUid/history/:type/", verifyFirebaseToken, async (req,res) 
         }
         const historicalData = await userService.getHistoricalData(userId, type, page, limit)
         if (!historicalData || historicalData.totalCount === 0) {
-            logInfo(`No historical data found for user ${userId} and type ${type}`);
+            logError(`No historical data found for user ${userId} and type ${type}`);
             return res.status(constants.STATUS_CODE.HTTP_NOT_FOUND).send({
                 message: "No historical data found for the specified criteria",
                 statusCode: constants.STATUS_CODE.HTTP_NOT_FOUND,

--- a/server/controller/userController.js
+++ b/server/controller/userController.js
@@ -122,7 +122,7 @@ router.put("/:firebaseUid/new-entry/:entryType", verifyFirebaseToken, async (req
     }
 });
 
-router.get("/:firebaseUid/history/:type/", async (req,res) => {
+router.get("/:firebaseUid/history/:type/", verifyFirebaseToken, async (req,res) => {
     const userId = req.params.firebaseUid;
     const type = req.params.type;
     const page = parseInt(req.query.page) || 1;
@@ -140,13 +140,13 @@ router.get("/:firebaseUid/history/:type/", async (req,res) => {
                 statusCode: constants.STATUS_CODE.HTTP_BAD_REQUEST
             }); 
         }
-        // if (req.user.uid !== userId) {
-        //     logError("Firebase User ID does not match request user ID");
-        //     return res.status(constants.STATUS_CODE.HTTP_FORBIDDEN).send({
-        //         message: "Forbidden - Cannot modify another user's data",
-        //         statusCode: constants.STATUS_CODE.HTTP_FORBIDDEN
-        //     });
-        // }
+        if (req.user.uid !== userId) {
+            logError("Firebase User ID does not match request user ID");
+            return res.status(constants.STATUS_CODE.HTTP_FORBIDDEN).send({
+                message: "Forbidden - Cannot modify another user's data",
+                statusCode: constants.STATUS_CODE.HTTP_FORBIDDEN
+            });
+        }
         if (!mappedType || mappedType == undefined) {
             logError(`Invalid type: ${type}`);
             return res.status(constants.STATUS_CODE.HTTP_BAD_REQUEST).send({

--- a/server/controller/userController.js
+++ b/server/controller/userController.js
@@ -133,7 +133,7 @@ router.get("/:firebaseUid/history/:type/", verifyFirebaseToken, async (req,res) 
     }
     const mappedType = validTypes[req.params.type]
     try {
-        if (userId == "" || !userId) {
+        if (userId.trim() === '' || !userId) {
            logError("No Firebase UID found in request");
             return res.status(constants.STATUS_CODE.HTTP_BAD_REQUEST).send({
                 message: "No Firebase UID provided",

--- a/server/controller/userController.js
+++ b/server/controller/userController.js
@@ -160,14 +160,6 @@ router.get("/:firebaseUid/history/:type/", verifyFirebaseToken, async (req,res) 
             return res.status(constants.STATUS_CODE.HTTP_NOT_FOUND).send({
                 message: "No historical data found for the specified criteria",
                 statusCode: constants.STATUS_CODE.HTTP_NOT_FOUND,
-                data: [],
-                pagination: {
-                    currentPage: page,
-                    totalPages: 0,
-                    totalItems: 0,
-                    hasNextPage: false,
-                    hasPreviousPage: false
-                }
             });
         }
         return res.status(200).send({

--- a/server/controller/userController.js
+++ b/server/controller/userController.js
@@ -122,4 +122,74 @@ router.put("/:firebaseUid/new-entry/:entryType", verifyFirebaseToken, async (req
     }
 });
 
+router.get("/:firebaseUid/history/:type/", async (req,res) => {
+    const userId = req.params.firebaseUid;
+    const type = req.params.type;
+    const page = parseInt(req.query.page) || 1;
+    const limit = parseInt(req.query.limit) || 10;
+    const validTypes = {
+        mood: "mood",
+        journal: "journal"
+    }
+    const mappedType = validTypes[req.params.type]
+    try {
+        if (userId == "" || !userId) {
+           logError("No Firebase UID found in request");
+            return res.status(constants.STATUS_CODE.HTTP_BAD_REQUEST).send({
+                message: "No Firebase UID provided",
+                statusCode: constants.STATUS_CODE.HTTP_BAD_REQUEST
+            }); 
+        }
+        // if (req.user.uid !== userId) {
+        //     logError("Firebase User ID does not match request user ID");
+        //     return res.status(constants.STATUS_CODE.HTTP_FORBIDDEN).send({
+        //         message: "Forbidden - Cannot modify another user's data",
+        //         statusCode: constants.STATUS_CODE.HTTP_FORBIDDEN
+        //     });
+        // }
+        if (!mappedType || mappedType == undefined) {
+            logError(`Invalid type: ${type}`);
+            return res.status(constants.STATUS_CODE.HTTP_BAD_REQUEST).send({
+                message: "Invalid type. Requested endpoint does not support this type.",
+                statusCode: constants.STATUS_CODE.HTTP_BAD_REQUEST
+            });
+        }
+        const historicalData = await userService.getHistoricalData(userId, type, page, limit)
+        if (!historicalData || historicalData.totalCount === 0) {
+            logInfo(`No historical data found for user ${userId} and type ${type}`);
+            return res.status(constants.STATUS_CODE.HTTP_NOT_FOUND).send({
+                message: "No historical data found for the specified criteria",
+                statusCode: constants.STATUS_CODE.HTTP_NOT_FOUND,
+                data: [],
+                pagination: {
+                    currentPage: page,
+                    totalPages: 0,
+                    totalItems: 0,
+                    hasNextPage: false,
+                    hasPreviousPage: false
+                }
+            });
+        }
+        return res.status(200).send({
+            message: "Historical data retrieved successfully",
+            statusCode: 200,
+            data: historicalData.data,
+            pagination: {
+                currentPage: page,
+                totalPages: historicalData.totalPages,
+                totalItems: historicalData.totalCount,
+                hasNextPage: page < historicalData.totalPages,
+                hasPreviousPage: page > 1
+            }
+        });
+    } catch (error) {
+       logError("Internal Server Error: " + error.message);
+        return res.status(constants.STATUS_CODE.HTTP_INTERNAL_SERVER_ERROR).send({
+            message: "Internal Server Error",
+            statusCode: constants.STATUS_CODE.HTTP_INTERNAL_SERVER_ERROR,
+            error: error.message
+        }); 
+    }
+})
+
 module.exports = router;


### PR DESCRIPTION
This change introduces:

- New endpoint to support historical data for a given user's journal or mood entries (returns 200 - Ok, 400 - Bad request from client, 403 - Forbidden, 404 - No data found, and 500 - Internal Server Error)
- Pagination logic for the new endpoint